### PR TITLE
Fix dropdown menu reappearing

### DIFF
--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -22,21 +22,20 @@
     on(selector, callback) {
       if (document.querySelector(selector)) {
         callback()
-        return
       }
-      const obs = new MutationObserver((mutations, observer) => {
+      const obs = new MutationObserver(mutations => {
         for (const m of mutations) {
           for (const node of m.addedNodes) {
             if (!(node instanceof HTMLElement)) continue
             if (node.matches(selector) || node.querySelector(selector)) {
               callback()
-              observer.disconnect()
               return
             }
           }
         }
       })
       obs.observe(document.body, { childList: true, subtree: true })
+      return obs
     }
   }
 


### PR DESCRIPTION
## Summary
- keep dom observer active so menu option reappears when avatar menu mounts

## Testing
- `node -c StopUnfollow.user.js`


------
https://chatgpt.com/codex/tasks/task_e_6844ada611b88333813fc548a46bb784