### PR TITLE
Fix duplicate import listener

### DIFF
--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -764,7 +764,6 @@
     }
     addBtn.addEventListener('click', handleAddButtonClick)
     addCurrent.addEventListener('click', handleAddCurrentClick)
-    importBtn.addEventListener('click', handleImportClick)
     searchInput.addEventListener('input', handleSearchInputChange)
     clearBtn.addEventListener('click', handleClearSearchClick)
     sortSelect.addEventListener('change', handleSortChange)


### PR DESCRIPTION
## Summary
- remove the earlier import button listener to avoid duplicate registration

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684de19a886c833399aec8bf85c94152