### PR TITLE
Fix duplicate import listener

### DIFF
--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -356,7 +356,7 @@
         font-size: 13px;
       }
       .tm-add-controls button.add-btn {
-        background: #9147ff;
+        background: #28a745;
         border: none;
         color: #fff;
         padding: 6px 10px;
@@ -365,7 +365,7 @@
         font-size: 12px;
       }
       .tm-add-controls button.add-btn:hover {
-        background: #772ce8;
+        background: #218838;
       }
       .tm-add-controls button.import-btn {
         background: #555;
@@ -764,7 +764,6 @@
     }
     addBtn.addEventListener('click', handleAddButtonClick)
     addCurrent.addEventListener('click', handleAddCurrentClick)
-    importBtn.addEventListener('click', handleImportClick)
     searchInput.addEventListener('input', handleSearchInputChange)
     clearBtn.addEventListener('click', handleClearSearchClick)
     sortSelect.addEventListener('change', handleSortChange)


### PR DESCRIPTION
## Summary
- remove the earlier import button listener to avoid duplicate registration
- make the Add by Text button green

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684de19a886c833399aec8bf85c94152