### PR TITLE
Add rename detection for saved Twitch channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Twitch-StopUnfollow is a Tampermonkey userscript that helps you avoid unfollowin
 - Import multiple channels at once; usernames are validated before adding.
 - Disables the Unfollow button on saved channels across navigation.
 - Automatically checks GitHub for updates and shows an Install button inside the menu when a newer version is detected.
+- Detects when a saved channel has been renamed and lets you update the entry with one click.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- detect renamed usernames via new `resolveRenamedChannel` helper
- highlight renamed entries in the list and offer an update button
- document rename detection feature in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68585a5ca4188333bd6b597daf951b10