### PR TITLE
Fix overlay unfollow click

### DIFF
--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -153,6 +153,7 @@
     btn.setAttribute('title', 'Disabled to prevent unfollow.')
     btn.style.opacity = '0.5'
     btn.style.cursor = 'not-allowed'
+    btn.style.pointerEvents = 'none'
   }
 
   function disableUnfollowIfSaved() {
@@ -179,6 +180,7 @@
       btn.removeAttribute('title')
       btn.style.opacity = ''
       btn.style.cursor = ''
+      btn.style.pointerEvents = ''
     })
   }
 


### PR DESCRIPTION
## Summary
- disable pointer events on "Unfollow" button when blocked
- re-enable pointer events when unblocking

## Testing
- `grep -n pointerEvents -n StopUnfollow.user.js | head`

------
https://chatgpt.com/codex/tasks/task_e_688b7bbcde048333b32b95f33f46b9d3