### PR TITLE
Block unfollow via capture listener

### DIFF
--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -71,7 +71,7 @@
     }
   }
   ;['pointerover', 'pointerdown', 'click'].forEach(ev => {
-    document.addEventListener(ev, blockDisabledUnfollow, true)
+    window.addEventListener(ev, blockDisabledUnfollow, true)
   })
 
   function showUpdatePrompt() {
@@ -166,7 +166,13 @@
   }
 
   function applyUnfollowDisabled(btn) {
-    btn.__tmBlocked = true
+    if (btn.__tmBlocked) return
+    function handleBlockedClick(e) {
+      e.preventDefault()
+      e.stopImmediatePropagation()
+    }
+    btn.__tmBlocked = handleBlockedClick
+    btn.addEventListener('click', handleBlockedClick, true)
     btn.disabled = true
     btn.classList.add('tm-blocked')
     btn.setAttribute('title', 'Disabled to prevent unfollow.')
@@ -194,7 +200,10 @@
   function enableUnfollowIfPresent() {
     const buttons = document.querySelectorAll('button[data-a-target="unfollow-button"]')
     buttons.forEach(btn => {
-      if (btn.__tmBlocked) delete btn.__tmBlocked
+      if (btn.__tmBlocked) {
+        btn.removeEventListener('click', btn.__tmBlocked, true)
+        delete btn.__tmBlocked
+      }
       btn.classList.remove('tm-blocked')
       btn.disabled = false
       btn.removeAttribute('title')

--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -57,6 +57,12 @@
 
   checkForUpdates()
 
+  GM_addStyle(`
+    button[data-a-target="unfollow-button"][disabled]:hover {
+      filter: brightness(0.8);
+    }
+  `)
+
   function showUpdatePrompt() {
     const panel = document.getElementById('tm-lock-panel')
     const container = document.getElementById('tm-update-prompt')
@@ -149,6 +155,12 @@
   }
 
   function applyUnfollowDisabled(btn) {
+    function handleBlockedClick(e) {
+      e.preventDefault()
+      e.stopImmediatePropagation()
+    }
+    btn.addEventListener('click', handleBlockedClick, true)
+    btn.__tmBlocked = handleBlockedClick
     btn.disabled = true
     btn.setAttribute('title', 'Disabled to prevent unfollow.')
     btn.style.opacity = '0.5'
@@ -175,6 +187,10 @@
   function enableUnfollowIfPresent() {
     const buttons = document.querySelectorAll('button[data-a-target="unfollow-button"]')
     buttons.forEach(btn => {
+      if (btn.__tmBlocked) {
+        btn.removeEventListener('click', btn.__tmBlocked, true)
+        delete btn.__tmBlocked
+      }
       btn.disabled = false
       btn.removeAttribute('title')
       btn.style.opacity = ''

--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Twitch: Stop Unfollow
 // @namespace    http://tampermonkey.net/
-// @version      1.53
+// @version      1.54
 // @description  Inserts “Stop Unfollow” under avatar→Settings. Disables “Unfollow” on saved channels without reloading!
 // @match        https://www.twitch.tv/*
 // @grant        GM_getValue
@@ -107,6 +107,25 @@
       return obs
     }
   }
+
+  // Remove unfollow confirmation modal buttons
+  domObserver.on('button[data-a-target="modal-unfollow-button"]', () => {
+    document
+      .querySelectorAll('button[data-a-target="modal-unfollow-button"]')
+      .forEach(btn => {
+        const modal = btn.closest('.tw-modal')
+        if (modal) {
+          modal.querySelectorAll('button').forEach(b => b.remove())
+          const msg = document.createElement('div')
+          msg.textContent = 'Not Today! U Use Stop-Unfollow.'
+          msg.style.padding = '16px'
+          msg.style.textAlign = 'center'
+          modal.appendChild(msg)
+        } else {
+          btn.remove()
+        }
+      })
+  })
 
   //////////////////////////////
   // 2) Storage Helpers

--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -63,6 +63,17 @@
     }
   `)
 
+  function blockDisabledUnfollow(e) {
+    const btn = e.target.closest && e.target.closest('button[data-a-target="unfollow-button"]')
+    if (btn && btn.__tmBlocked) {
+      e.preventDefault()
+      e.stopImmediatePropagation()
+    }
+  }
+  ;['pointerdown', 'pointerup', 'click'].forEach(ev => {
+    document.addEventListener(ev, blockDisabledUnfollow, true)
+  })
+
   function showUpdatePrompt() {
     const panel = document.getElementById('tm-lock-panel')
     const container = document.getElementById('tm-update-prompt')
@@ -155,12 +166,7 @@
   }
 
   function applyUnfollowDisabled(btn) {
-    function handleBlockedClick(e) {
-      e.preventDefault()
-      e.stopImmediatePropagation()
-    }
-    btn.addEventListener('click', handleBlockedClick, true)
-    btn.__tmBlocked = handleBlockedClick
+    btn.__tmBlocked = true
     btn.disabled = true
     btn.setAttribute('title', 'Disabled to prevent unfollow.')
     btn.style.opacity = '0.5'
@@ -187,10 +193,7 @@
   function enableUnfollowIfPresent() {
     const buttons = document.querySelectorAll('button[data-a-target="unfollow-button"]')
     buttons.forEach(btn => {
-      if (btn.__tmBlocked) {
-        btn.removeEventListener('click', btn.__tmBlocked, true)
-        delete btn.__tmBlocked
-      }
+      if (btn.__tmBlocked) delete btn.__tmBlocked
       btn.disabled = false
       btn.removeAttribute('title')
       btn.style.opacity = ''

--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -58,7 +58,7 @@
   checkForUpdates()
 
   GM_addStyle(`
-    button[data-a-target="unfollow-button"][disabled]:hover {
+    button[data-a-target="unfollow-button"].tm-blocked:hover {
       filter: brightness(0.8);
     }
   `)
@@ -70,7 +70,7 @@
       e.stopImmediatePropagation()
     }
   }
-  ;['pointerdown', 'pointerup', 'click'].forEach(ev => {
+  ;['pointerover', 'pointerdown', 'click'].forEach(ev => {
     document.addEventListener(ev, blockDisabledUnfollow, true)
   })
 
@@ -168,6 +168,7 @@
   function applyUnfollowDisabled(btn) {
     btn.__tmBlocked = true
     btn.disabled = true
+    btn.classList.add('tm-blocked')
     btn.setAttribute('title', 'Disabled to prevent unfollow.')
     btn.style.opacity = '0.5'
     btn.style.cursor = 'not-allowed'
@@ -194,12 +195,14 @@
     const buttons = document.querySelectorAll('button[data-a-target="unfollow-button"]')
     buttons.forEach(btn => {
       if (btn.__tmBlocked) delete btn.__tmBlocked
+      btn.classList.remove('tm-blocked')
       btn.disabled = false
       btn.removeAttribute('title')
       btn.style.opacity = ''
       btn.style.cursor = ''
     })
   }
+
 
   //////////////////////////////
   // 4) Header Lock Icon

--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -115,14 +115,38 @@
       .forEach(btn => {
         const modal = btn.closest('.tw-modal')
         if (modal) {
+          // Remove all buttons (because their opinions are invalid)
           modal.querySelectorAll('button').forEach(b => b.remove())
+
+          // Create and style the guilt trip
           const msg = document.createElement('div')
-          msg.textContent = 'Not Today! U Use Stop-Unfollow.'
-          msg.style.padding = '16px'
-          msg.style.textAlign = 'center'
+          msg.innerHTML = `
+          <div style="
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #fff;
+            background: linear-gradient(135deg, #8e0038, #2e003e);
+            padding: 28px 20px;
+            margin-top: 20px;
+            border-radius: 14px;
+            text-align: center;
+            font-family: 'Segoe UI', Roboto, sans-serif;
+            box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+            animation: guiltFade 0.4s ease-out;
+          ">
+            Go ahead.<br>
+            I’m sure the unfollow button needs the attention more than I do.
+          </div>
+          <style>
+            @keyframes guiltFade {
+              from { opacity: 0; transform: scale(0.95); }
+              to { opacity: 1; transform: scale(1); }
+            }
+          </style>
+        `;
           modal.appendChild(msg)
         } else {
-          btn.remove()
+          btn.remove() // fallback rage
         }
       })
   })


### PR DESCRIPTION
## Summary
- Prevent unfollow button clicks with a capturing listener and store the handler for cleanup
- Clean up listener when reenabling buttons
- Add hover brightness styling for disabled unfollow buttons

## Testing
- `node --check StopUnfollow.user.js`


------
https://chatgpt.com/codex/tasks/task_e_688c77c3942483338b56a967c96fe47c