### PR TITLE
Prevent unfollow via tooltip or modal

### DIFF
--- a/StopUnfollow.user.js
+++ b/StopUnfollow.user.js
@@ -1208,26 +1208,24 @@ async function onAddCurrent() {
 
   function hookUnfollowTooltip() {
     if (tooltipObserver) tooltipObserver.disconnect()
-    tooltipObserver = domObserver.on(
-      '.tw-tooltip-layer .tw-tooltip-wrapper',
-      () => {
-        document
-          .querySelectorAll('.tw-tooltip-layer .tw-tooltip-wrapper')
-          .forEach(wrapper => {
-            const text = wrapper.textContent.trim().toLowerCase()
-            if (text === 'unfollow' || text === 'nicht mehr folgen') {
-              const layer = wrapper.closest('.tw-tooltip-layer')
-              if (layer) {
-                layer.querySelectorAll('div').forEach(el => el.remove())
-                layer.style.pointerEvents = 'none'
-                layer.appendChild(createGuiltTripMessage())
-              } else {
-                wrapper.remove()
-              }
-            }
-          })
-      }
-    )
+    tooltipObserver = domObserver.on('.tw-tooltip-layer', () => {
+      document.querySelectorAll('.tw-tooltip-layer').forEach(layer => {
+        const wrapper = layer.querySelector('.tw-tooltip-wrapper')
+        const text = wrapper?.textContent.trim().toLowerCase()
+        if (text === 'unfollow' || text === 'nicht mehr folgen') {
+          const content = layer.querySelector(
+            '.ReactModal__Content[role="tooltip"]'
+          )
+          if (content) {
+            content.replaceChildren(createGuiltTripMessage())
+            content.style.pointerEvents = 'none'
+          } else {
+            layer.replaceChildren(createGuiltTripMessage())
+            layer.style.pointerEvents = 'none'
+          }
+        }
+      })
+    })
   }
 
   //////////////////////////////


### PR DESCRIPTION
## Summary
- Add modal and tooltip observers that remove unfollow buttons and insert a guilt-trip message
- Wire observers into initial load and SPA navigation

## Testing
- `node --check StopUnfollow.user.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c99d2f3188333bb07d47ad112f129